### PR TITLE
Sprint 25 TLT-1677 Clean up module item required argument handling

### DIFF
--- a/canvas_sdk/methods/modules.py
+++ b/canvas_sdk/methods/modules.py
@@ -251,7 +251,7 @@ def show_module_item(request_ctx, course_id, module_id, id, include, student_id=
     return response
 
 
-def create_module_item(request_ctx, course_id, module_id, module_item_type, module_item_content_id, module_item_page_url, module_item_external_url, module_item_completion_requirement_min_score, module_item_title=None, module_item_position=None, module_item_indent=None, module_item_new_tab=None, module_item_completion_requirement_type=None, **request_kwargs):
+def create_module_item(request_ctx, course_id, module_id, module_item_type, module_item_content_id, module_item_page_url=None, module_item_external_url=None, module_item_completion_requirement_min_score=None, module_item_title=None, module_item_position=None, module_item_indent=None, module_item_new_tab=None, module_item_completion_requirement_type=None, **request_kwargs):
     """
     Create and return a new module item
 
@@ -287,9 +287,15 @@ def create_module_item(request_ctx, course_id, module_id, module_item_type, modu
     """
 
     module_item_type_types = ('File', 'Page', 'Discussion', 'Assignment', 'Quiz', 'SubHeader', 'ExternalUrl', 'ExternalTool')
-    module_item_completion_requirement_type_types = ('must_view', 'must_contribute', 'must_submit')
+    module_item_completion_requirement_type_types = ('must_view', 'must_contribute', 'must_submit', 'min_score')
     utils.validate_attr_is_acceptable(module_item_type, module_item_type_types)
     utils.validate_attr_is_acceptable(module_item_completion_requirement_type, module_item_completion_requirement_type_types)
+    if module_item_type == 'Page' and module_item_page_url is None:
+        raise ValueError('module_item_page_url must be set for Page items')
+    if module_item_type in ('ExternalUrl', 'ExternalTool') and module_item_external_url is None:
+        raise ValueError('module_item_external_url must be set for ExternalUrl or ExternalTool items')
+    if module_item_completion_requirement_type == 'min_score' and module_item_completion_requirement_min_score is None:
+        raise ValueError('module_item_completion_requirement_min_score must be set for min_score requirement types')
     path = '/v1/courses/{course_id}/modules/{module_id}/items'
     payload = {
         'module_item[title]' : module_item_title,
@@ -309,7 +315,7 @@ def create_module_item(request_ctx, course_id, module_id, module_item_type, modu
     return response
 
 
-def update_module_item(request_ctx, course_id, module_id, id, module_item_completion_requirement_min_score, module_item_title=None, module_item_position=None, module_item_indent=None, module_item_external_url=None, module_item_new_tab=None, module_item_completion_requirement_type=None, module_item_published=None, module_item_module_id=None, **request_kwargs):
+def update_module_item(request_ctx, course_id, module_id, id, module_item_completion_requirement_min_score=None, module_item_title=None, module_item_position=None, module_item_indent=None, module_item_external_url=None, module_item_new_tab=None, module_item_completion_requirement_type=None, module_item_published=None, module_item_module_id=None, **request_kwargs):
     """
     Update and return an existing module item
 
@@ -344,8 +350,13 @@ def update_module_item(request_ctx, course_id, module_id, id, module_item_comple
 
     """
 
-    module_item_completion_requirement_type_types = ('must_view', 'must_contribute', 'must_submit')
+    module_item_completion_requirement_type_types = ('must_view', 'must_contribute', 'must_submit', 'min_score')
     utils.validate_attr_is_acceptable(module_item_completion_requirement_type, module_item_completion_requirement_type_types)
+    if module_item_type in ('ExternalUrl', 'ExternalTool') and module_item_external_url is None:
+        raise ValueError('module_item_external_url must be set for ExternalUrl or ExternalTool items')
+    if module_item_completion_requirement_type == 'min_score' and module_item_completion_requirement_min_score is None:
+        raise ValueError('module_item_completion_requirement_min_score must be set for min_score requirement types')
+
     path = '/v1/courses/{course_id}/modules/{module_id}/items/{id}'
     payload = {
         'module_item[title]' : module_item_title,

--- a/static_methods/modules.py
+++ b/static_methods/modules.py
@@ -1,0 +1,85 @@
+from canvas_sdk import client, utils
+
+def create_module(request_ctx, course_id, module_name, module_unlock_at=None, module_position=None, module_require_sequential_progress=None, module_prerequisite_module_ids=None, module_publish_final_grade=None, **request_kwargs):
+    """
+    Create and return a new module
+
+        :param request_ctx: The request context
+        :type request_ctx: :class:RequestContext
+        :param course_id: (required) ID
+        :type course_id: string
+        :param module_name: (required) The name of the module
+        :type module_name: string
+        :param module_unlock_at: (optional) The date the module will unlock
+        :type module_unlock_at: datetime or None
+        :param module_position: (optional) The position of this module in the course (1-based)
+        :type module_position: integer or None
+        :param module_require_sequential_progress: (optional) Whether module items must be unlocked in order
+        :type module_require_sequential_progress: boolean or None
+        :param module_prerequisite_module_ids: (optional) IDs of Modules that must be completed before this one is unlocked. Prerequisite modules must precede this module (i.e. have a lower position value), otherwise they will be ignored
+        :type module_prerequisite_module_ids: string or None
+        :param module_publish_final_grade: (optional) Whether to publish the student's final grade for the course upon completion of this module.
+        :type module_publish_final_grade: boolean or None
+        :return: Create a module
+        :rtype: requests.Response (with Module data)
+
+    """
+
+    path = '/v1/courses/{course_id}/modules'
+    payload = {
+        'module[name]' : module_name,
+        'module[unlock_at]' : module_unlock_at,
+        'module[position]' : module_position,
+        'module[require_sequential_progress]' : module_require_sequential_progress,
+        'module[prerequisite_module_ids]' : module_prerequisite_module_ids,
+        'module[publish_final_grade]' : module_publish_final_grade,
+    }
+    url = request_ctx.base_api_url + path.format(course_id=course_id)
+    response = client.post(request_ctx, url, payload=payload, **request_kwargs)
+
+    return response
+
+
+def update_module(request_ctx, course_id, id, module_name=None, module_unlock_at=None, module_position=None, module_require_sequential_progress=None, module_prerequisite_module_ids=None, module_publish_final_grade=None, module_published=None, **request_kwargs):
+    """
+    Update and return an existing module
+
+        :param request_ctx: The request context
+        :type request_ctx: :class:RequestContext
+        :param course_id: (required) ID
+        :type course_id: string
+        :param id: (required) ID
+        :type id: string
+        :param module_name: (optional) The name of the module
+        :type module_name: string or None
+        :param module_unlock_at: (optional) The date the module will unlock
+        :type module_unlock_at: datetime or None
+        :param module_position: (optional) The position of the module in the course (1-based)
+        :type module_position: integer or None
+        :param module_require_sequential_progress: (optional) Whether module items must be unlocked in order
+        :type module_require_sequential_progress: boolean or None
+        :param module_prerequisite_module_ids: (optional) IDs of Modules that must be completed before this one is unlocked Prerequisite modules must precede this module (i.e. have a lower position value), otherwise they will be ignored
+        :type module_prerequisite_module_ids: string or None
+        :param module_publish_final_grade: (optional) Whether to publish the student's final grade for the course upon completion of this module.
+        :type module_publish_final_grade: boolean or None
+        :param module_published: (optional) Whether the module is published and visible to students
+        :type module_published: boolean or None
+        :return: Update a module
+        :rtype: requests.Response (with Module data)
+
+    """
+
+    path = '/v1/courses/{course_id}/modules/{id}'
+    payload = {
+        'module[name]' : module_name,
+        'module[unlock_at]' : module_unlock_at,
+        'module[position]' : module_position,
+        'module[require_sequential_progress]' : module_require_sequential_progress,
+        'module[prerequisite_module_ids]' : module_prerequisite_module_ids,
+        'module[publish_final_grade]' : module_publish_final_grade,
+        'module[published]' : module_published,
+    }
+    url = request_ctx.base_api_url + path.format(course_id=course_id, id=id)
+    response = client.put(request_ctx, url, payload=payload, **request_kwargs)
+
+    return response


### PR DESCRIPTION
According to the api docs, some arguments are required some of the time,
based on the values of other arguments.  This change makes the
sometimes-required arguments optional in the function definition, but
checks for their existence when they're actually required.